### PR TITLE
fix-absolute-path-redirect

### DIFF
--- a/public/blog/what-is-base58.html
+++ b/public/blog/what-is-base58.html
@@ -83,7 +83,7 @@ Base58: TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL</code></pre>
       </ul>
       <p>
         Want to learn how validation works? Read
-        <a href="/validating-tron-addresses.html"
+        <a href="/blog/validating-tron-addresses.html"
           >Validating TRON Addresses Securely</a
         >.
       </p>

--- a/public/blog/what-is-base58.html
+++ b/public/blog/what-is-base58.html
@@ -83,7 +83,7 @@ Base58: TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL</code></pre>
       </ul>
       <p>
         Want to learn how validation works? Read
-        <a href="/blog/validating-tron-addresses.html"
+        <a href="validating-tron-addresses.html"
           >Validating TRON Addresses Securely</a
         >.
       </p>


### PR DESCRIPTION
currently when I click on:
<img width="2166" height="1526" alt="image" src="https://github.com/user-attachments/assets/2aa47621-8f74-4822-883a-fd82d11be18c" />
it leads me to the homepage.
<img width="1213" height="734" alt="image" src="https://github.com/user-attachments/assets/16ba7928-98a2-4530-b692-8b04fb085b40" />

Chat is telling me that when a href starts with a slash, it's treated as an absolute path. This PR fixes the link to be a relative path.

Testing: I asked chatgpt if my changes look ok